### PR TITLE
New design matching the existing part

### DIFF
--- a/SwayBarSpacer.json
+++ b/SwayBarSpacer.json
@@ -1,0 +1,17 @@
+{
+    "parameterSets": {
+        "initial values": {
+            "$fn": "30",
+            "DentDepth": "3",
+            "DentLengthBottom": "9",
+            "DentLengthTop": "20",
+            "HoleDiameter": "8",
+            "HoleDistance": "50",
+            "PartChamfer": "10",
+            "PartLength": "67",
+            "PartThickness": "5",
+            "PartWidth": "36"
+        }
+    },
+    "fileFormatVersion": "1"
+}

--- a/SwayBarSpacer.scad
+++ b/SwayBarSpacer.scad
@@ -1,42 +1,51 @@
 /*
  * Sway Bar Spacer for Dave's Cayman
  */
-$fn = 60;
+$fn = 30;
 
-PartWidth = 36;
-PartLength = 67;
-PartChamfer = 10;
-PartThickness = 10;
+PartWidth = 36.1;
+PartLength = 67.1;
+PartChamfer = 10.1;
+PartThickness = 5.1;
 
-HoleDiameter = 8;
-HoleDistance = 50;
+HoleDiameter = 8.1;
+HoleDistance = 50.1;
 
-BushingDiameter = 40;
-BushingIndent = 5;
-IndentLength = 9;
+DentLengthTop = 20.1;
+DentLengthBottom = 9.1;
+DentDepth = 3.1;
 
-// Drill holes
-difference() {
-    // Cut out the space for the bushing from the main part
+union() {
     difference() {
-	// Build a union of the main polygon and the block extending
-	// into the indentation of the mounting bracket
+	// Take the main profile
+	Z_profile();
+	// cut out the indented center and the holes for the bolts
 	union() {
-	    // Main polygon
-	    Z_profile();
-
-	    // Block
-	    translate([-PartWidth / 2, -IndentLength / 2, PartThickness - 0.1])
-		cube([PartWidth, IndentLength, BushingIndent + 0.1], center = false);
+	    translate([0, 0, PartThickness / 2])
+		cube(size=[PartWidth + 0.02, DentLengthTop, PartThickness + 0.2],
+		     center = true);
+	    Holes();
 	}
-
-	// Circular cut out for the bushing
-	translate([0, 0, -BushingDiameter / 2 + BushingIndent])
-	    rotate([0, 90, 0])
-	    cylinder(r = BushingDiameter / 2, h = PartWidth + 2, center = true);
     }
-    // The drill holes
-    Holes();
+
+    // Add the flat bottom part
+    translate([0, 0, PartThickness / 2 - DentDepth])
+	cube(size=[PartWidth, DentLengthBottom, PartThickness], center=true);
+
+
+    // Add the angled pieces
+    Angle_part();
+    mirror([0, 180, 0])
+	Angle_part();
+}
+
+module Angle_part() {
+    hull() {
+    translate([0, DentLengthBottom / 2, PartThickness / 2 - DentDepth])
+    cube(size=[PartWidth, 0.01, PartThickness], center=true);
+    translate([0, DentLengthTop / 2, PartThickness / 2])
+    cube(size=[PartWidth, 0.01, PartThickness], center=true);
+    }
 }
 
 Z_points = [
@@ -47,20 +56,29 @@ Z_points = [
 	[PartWidth / 2 - PartChamfer, PartLength / 2],
 	[PartWidth / 2, PartLength / 2 - PartChamfer],
 	[PartWidth / 2, -PartLength / 2 + PartChamfer],
-	[PartWidth / 2 - PartChamfer, -PartLength / 2]
+	[PartWidth / 2 - PartChamfer, -PartLength / 2],
+	[-PartWidth / 2 + PartChamfer, -PartLength / 2],
     ];
 
 module Z_profile() {
     linear_extrude(height = PartThickness) {
-        polygon(points = Z_points);
+	difference() {
+	    polygon(points = Z_points);
+	    /*
+	    translate([0, HoleDistance / 2])
+		circle(r=HoleDiameter / 2);
+	    translate([0, -HoleDistance / 2])
+		circle(r=HoleDiameter / 2);
+	    */
+	}
     }
 }
 
 module Holes() {
-    translate([0, -HoleDistance / 2, -0.1])
-	cylinder(r = HoleDiameter / 2, h = 20);
-    translate([0, HoleDistance / 2, -0.1])
-	cylinder(r = HoleDiameter / 2, h = 20);
+    union() {
+	translate([0, -HoleDistance / 2, -0.1])
+	    cylinder(r = HoleDiameter / 2, h = PartThickness + 0.2);
+	translate([0, HoleDistance / 2, -0.1])
+	    cylinder(r = HoleDiameter / 2, h = PartThickness + 0.2);
+    }
 }
-
-


### PR DESCRIPTION
I changed the design to use angled surfaces as they are in the original part. Everything is parameterized so it can be changed in the "Customizer" without modifying the source code.

There is a known problem with the Customizer in that you cannot specify a precision for the values. If you use whole numbers, the UI restricts changes to whole numbers. Even when using 'var = 36.0' the UI will display 36 and won't let you enter any decimals. The trick is to add as many non-zero decimals as you want and then create a parameter preset.